### PR TITLE
feat: custom types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
-        "@envuse/wasm": "^1.2.0"
+        "@envuse/wasm": "^1.5.0"
       },
       "devDependencies": {
         "@jondotsoy/demo-workspace": "^1.1.3",
@@ -30,7 +30,7 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "dotenv": "^16.0.3"
+        "dotenv": "*"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/@envuse/wasm": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@envuse/wasm/-/wasm-1.4.0.tgz",
-      "integrity": "sha512-N7qzjZSGM+m3PdybyL0NnYUB43UuYPqWYLACeYGEvDRDAPryTLNPTmFxU77QPl7INGfgRY7ihpXT/QGfgx3+7g=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@envuse/wasm/-/wasm-1.5.0.tgz",
+      "integrity": "sha512-7r7wCGxRb+X9td+P0feugnJPgX9FhlMWND9J/gt9Zy/alkafNaro0GkqYfT0162M3cK9t7ZhXynrHNnSJJg+UQ=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.16.17",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "author": "Jonathan Delgado <hi@jon.soy> (https://jon.soy)",
   "license": "MIT",
   "dependencies": {
-    "@envuse/wasm": "^1.2.0"
+    "@envuse/wasm": "^1.5.0"
   },
   "repository": {
     "url": "https://github.com/JonDotsoy/envuse.js.git",

--- a/src/parse_options.mts
+++ b/src/parse_options.mts
@@ -3,4 +3,5 @@ export interface ParseOptions {
   defFileLocation?: URL;
   typesFileLocation?: URL;
   envs?: Record<string, string | undefined>;
+  customTypes?: Record<string, (value: string) => any>;
 }

--- a/tests/envuse.test.ts
+++ b/tests/envuse.test.ts
@@ -273,3 +273,28 @@ describe("E2E tests", () => {
       `);
   }, 60_000);
 });
+
+describe("Custom Types", () => {
+  it("should parse", async () => {
+    const workspace = demoWorkspace({ workspaceName: "Sample4" });
+
+    workspace.makeTree({
+      '.def.json': '{}',
+      "1.envuse": `
+        FOO: Strange
+      `,
+    });
+
+    parse("1.envuse", {
+      defFileLocation: new URL('.def.json', workspace.cwd),
+      typesFileLocation: new URL('.types.d.ts', workspace.cwd),
+      cwd: workspace.cwd,
+      customTypes: {
+        strange: (value: string) => Symbol.for(value),
+      },
+      envs: {
+        FOO: "BAZ",
+      },
+    });
+  });
+});

--- a/tests/envuse.test.ts
+++ b/tests/envuse.test.ts
@@ -274,20 +274,21 @@ describe("E2E tests", () => {
   }, 60_000);
 });
 
-describe("Custom Types", () => {
+describe.only("Custom Types", () => {
   it("should parse", async () => {
     const workspace = demoWorkspace({ workspaceName: "Sample4" });
 
     workspace.makeTree({
-      '.def.json': '{}',
+      ".def.json": "{}",
       "1.envuse": `
-        FOO: Strange
+        AAA = "asd"
+        FOO: Strange = ""
       `,
     });
 
-    parse("1.envuse", {
-      defFileLocation: new URL('.def.json', workspace.cwd),
-      typesFileLocation: new URL('.types.d.ts', workspace.cwd),
+    const parsed = parse("1.envuse", {
+      defFileLocation: new URL(".def.json", workspace.cwd),
+      typesFileLocation: new URL(".types.d.ts", workspace.cwd),
       cwd: workspace.cwd,
       customTypes: {
         strange: (value: string) => Symbol.for(value),
@@ -296,5 +297,12 @@ describe("Custom Types", () => {
         FOO: "BAZ",
       },
     });
+
+    expect(parsed).toMatchInlineSnapshot(`
+      {
+        "AAA": "asd",
+        "FOO": Symbol(BAZ),
+      }
+    `);
   });
 });


### PR DESCRIPTION
## Allow use of the custom types


To an envuse file

```envuse
FOO: Strage
```

In the parser can be use the property `customTypes`.

```ts
parse("1.envuse", {
  customTypes: {
    strange: (value: string) => Symbol.for(value),
  }
}
```
